### PR TITLE
Clarify the license

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -44,7 +44,8 @@ Subtitle := "FrancyMonoids/A package to display commutative monoid objects with 
 Version := "0.1",
 ##  Release date of the current version in dd/mm/yyyy format.
 ##
-Date := "04/06/2018",
+Date := "04/06/2018", # dd/mm/yyyy format
+License := "GPL-2.0-or-later",
 ##  Optional: if the package manual uses GAPDoc, you may duplicate the 
 ##  version and the release date as shown below to read them while building
 ##  the manual using GAPDoc facilities to distibute documents across files.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ This package requires [francy](https://github.com/mcmartins/francy) and [numeric
 ## Example
 
 See the example in this [notebook](https://github.com/pedritomelenas/francy-monoids/blob/master/Examples/francy-monoids.ipynb).
+
+## License
+
+FrancyMonoids is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2 of the License, or (at your
+option) any later version.


### PR DESCRIPTION
Clarify that FrancyMonoids is available under the GPL2 or later,
and also add a corresponding License field to PackageInfo.g

Well, at least I am assuming (and hoping) that this is the license you have in mind (matching the license terms of GAP itself).